### PR TITLE
feat: sitemap generator links to available subproject sitemap

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,7 +19,7 @@ extensions = [
     ]
 
 exclude_patterns = ['_build', '.sphinx']
-html_extra_paths = ["sitemap.xml"]
+html_extra_path = ["sitemap.xml", "robots.txt"]
 
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Disallow: # Allow everything
+
+Sitemap: https://documentation.ubuntu.com/latest/sitemap.xml

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -39,13 +39,13 @@ def main():
             continue
 
         logging.debug(
-            f"Checking existence of sitemap for {item["child"]["urls"]["documentation"]}"
+            f'Checking existence of sitemap for {item["child"]["urls"]["documentation"]}'
         )
         code = requests.get(
-            f"{item["child"]["urls"]["documentation"]}sitemap.xml"
+            f'{item["child"]["urls"]["documentation"]}sitemap.xml'
         ).status_code
         logging.debug(
-            f"{item["child"]["urls"]["documentation"]}sitemap.xml STATUS={str(code)}"
+            f'{item["child"]["urls"]["documentation"]}sitemap.xml STATUS={str(code)}'
         )
         if code == 200:
 
@@ -53,10 +53,10 @@ def main():
                 item["child"]["modified"]
             ).strftime("%Y-%m-%d")
             children.update(
-                {f"{item["child"]["urls"]["documentation"]}sitemap.xml": modified}
+                {f'{item["child"]["urls"]["documentation"]}sitemap.xml': modified}
             )
             logging.debug(
-                f"Adding {item["child"]["urls"]["documentation"]} to the sitemap"
+                f'Adding {item["child"]["urls"]["documentation"]} to the sitemap'
             )
 
     for key, value in children.items():

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -1,25 +1,32 @@
 #! /usr/bin/env python
 
+# NOTE: This script requires an RTD API token to be provided through the environment to function
+
 import requests
 import os
 import datetime
+import logging
 from requests.exceptions import RequestException
 
-PROJECT_URL = 'https://readthedocs.com/api/v3/projects/canonical-ubuntu-documentation-library/'
-SUBPROJECT_URL = 'https://readthedocs.com/api/v3/projects/canonical-ubuntu-documentation-library/subprojects/?limit=50'
+PROJECT_URL = (
+    "https://readthedocs.com/api/v3/projects/canonical-ubuntu-documentation-library/"
+)
+SUBPROJECT_URL = "https://readthedocs.com/api/v3/projects/canonical-ubuntu-documentation-library/subprojects/?limit=50"
+TOKEN = os.environ["TOKEN"]
+TIMEOUT = 10  # seconds
+EXCEPTIONS_LIST = ["https://documentation.ubuntu.com/security-team/en/latest/"]
 
-# Ensure an RTD access token is exported and available in the build environment
-TOKEN = os.environ.get("TOKEN")
+# Check if debugging
+if os.getenv("DEBUGGING"):
+    logging.basicConfig(level=logging.DEBUG)
+
 
 def main():
-    """Generates a sitemap from RTD for the Ubuntu documentation library."""
+
+    # print(authorised_get("https://documentation.ubuntu.com/dedicated-snap-store/", TOKEN).status_code)
+    # return
 
     template_sitemap = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
-
-    # Get and update main project data
-    project = authorised_get(PROJECT_URL, TOKEN)
-    project_data = project.json()
-    template_sitemap = "{}\n{}".format(template_sitemap, template_sitemap_section("https://documentation.ubuntu.com/en/latest/", datetime.datetime.fromisoformat(project_data["modified"]).strftime("%Y-%m-%d")))
 
     # Get and update subproject data
     subprojects = authorised_get(SUBPROJECT_URL, TOKEN)
@@ -27,31 +34,62 @@ def main():
     children = {}
 
     for item in subproject_data["results"]:
-        modified = datetime.datetime.fromisoformat(item["child"]["modified"]).strftime("%Y-%m-%d")
-        children.update({item["child"]["urls"]["documentation"]: modified})
+
+        if item["child"]["urls"]["documentation"] in EXCEPTIONS_LIST:
+            continue
+
+        logging.debug(
+            f"Checking existence of sitemap for {item["child"]["urls"]["documentation"]}"
+        )
+        code = requests.get(
+            f"{item["child"]["urls"]["documentation"]}sitemap.xml"
+        ).status_code
+        logging.debug(
+            f"{item["child"]["urls"]["documentation"]}sitemap.xml STATUS={str(code)}"
+        )
+        if code == 200:
+
+            modified = datetime.datetime.fromisoformat(
+                item["child"]["modified"]
+            ).strftime("%Y-%m-%d")
+            children.update(
+                {f"{item["child"]["urls"]["documentation"]}sitemap.xml": modified}
+            )
+            logging.debug(
+                f"Adding {item["child"]["urls"]["documentation"]} to the sitemap"
+            )
 
     for key, value in children.items():
-        template_sitemap = "{}\n{}".format(template_sitemap, template_sitemap_section(key, value))
+        template_sitemap = "{}\n{}".format(
+            template_sitemap, template_sitemap_section(key, value)
+        )
 
     # Write sitemap
-    sitemap = open("sitemap.xml", "w")
-    sitemap.write(template_sitemap + "\n</urlset>")
+    try:
+        logging.debug("writing sitemap")
+        sitemap = open("sitemap.xml", "w")
+        sitemap.write(f"{template_sitemap}\n</urlset>")
+    except Exception as e:
+        raise e
+
 
 # Format URL and modification date into sitemap compliant string
 def template_sitemap_section(loc, lastmod):
-    template = "<url>\n<loc>{}</loc>\n<lastmod>{}</lastmod>\n</url>".format(loc, lastmod)
+    template = f"<url>\n<loc>{loc}</loc>\n<lastmod>{lastmod}</lastmod>\n</url>"
     return template
+
 
 # GET query a URL with an auth token
 def authorised_get(url, token):
 
-    HEADERS = {'Authorization': f'token {token}'}
+    logging.debug(f"Querying {url}")
+    HEADERS = {"Authorization": f"token {token}"}
     try:
-        response = requests.get(url, headers=HEADERS, timeout=10)
+        response = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
+        return response
     except RequestException as e:
-        print(f"Failed query_api(): {url}")
-        raise SystemExit(e)
-    return response
+        raise RuntimeError(f"Failed authorised_get(): {url}") from e
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Also adds some logging for debugging purposes.

Essentially, for discoverability it's important to have sitemap coverage for all available documentation pages for each subproject. If we deploy sitemaps on each subproject, this script pulls information on each subproject and queries the availability of the sitemap, if the sitemap is available it adds it to the sitemap for the main URL.

This will create a 'web' of sitemaps covering all documentation pages once all subprojects are deployed with sitemaps.

Currently only the Dedicated Snap Store documentation is set up with a sitemap, as deploying a sitemap on a subproject involves a workaround with a placeholder file.

Additional advice will be provided on setting up a sitemap for RTD projects soon.